### PR TITLE
fix PuntTV canvas display in Safari

### DIFF
--- a/punttv/css/style.css
+++ b/punttv/css/style.css
@@ -70,6 +70,11 @@ main > div {
 }
 
 .canvas {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   display: block;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
`height: 100%` is not enough for Safari to recognize the parent's height, that's all there was to it!

I can't remember where I picked up the `top:0; right:0; bottom:0; left:0` trick and I can't find it right now. But I promise it makes sense 🤓 

![screen shot 2017-08-28 at 19 56 54](https://user-images.githubusercontent.com/2104122/29786338-19ec4a28-8c2b-11e7-9e21-cd2dc17b87e1.png)
